### PR TITLE
debug: Add drgn script

### DIFF
--- a/debug/md.py
+++ b/debug/md.py
@@ -1,0 +1,46 @@
+from drgn.helpers.linux.block import for_each_disk
+from drgn.helpers.linux.list import hlist_for_each_entry
+from drgn import Object, sizeof
+
+MD_MAJOR = 9
+
+class MDException(Exception):
+    def __init__(self, msg, mddev=None):
+        if mddev is not None:
+            disk_name = mddev.gendisk.disk_name.string_().decode()
+            msg = f"{disk_name}: {msg}"
+        super().__init__(msg)
+
+def find_disk(prog, name):
+    for disk in for_each_disk(prog):
+        if disk.disk_name.string_() == name.encode():
+            return disk
+
+def find_mddev(prog, disk_name="md0"):
+    disk = find_disk(prog, disk_name)
+    if disk is None:
+        raise MDException(f"{disk_name} doesn't exist")
+
+    if disk.major != MD_MAJOR:
+        raise MDException(f"{disk_name} is not an md device")
+
+    return Object(prog, "struct mddev", address=disk.private_data)
+
+def get_raid5_conf(mddev):
+    if mddev.level not in (4, 5, 6):
+        raise MDException(f"not a raid5 device", mddev)
+
+    return Object(mddev.prog_, "struct r5conf", address=mddev.private)
+
+def find_hashed_stripes(conf):
+    PAGE_SIZE = 4096
+    NR_HASH = PAGE_SIZE // sizeof(conf.stripe_hashtbl[0])
+
+    stripes = []
+    for i in range(NR_HASH):
+        for s in hlist_for_each_entry('struct stripe_head',
+                                      conf.stripe_hashtbl[i].address_of_(),
+                                      'hash'):
+            stripes.append(s)
+
+    return stripes

--- a/debug/raid5_active.py
+++ b/debug/raid5_active.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env drgn
+
+import argparse
+import sys
+
+import md
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("disk", nargs="?", default="md0")
+    args = parser.parse_args()
+
+    try:
+        mddev = md.find_mddev(prog, args.disk)
+        conf = md.get_raid5_conf(mddev)
+
+        print(f"Active Stripes:  {int(conf.active_stripes.counter)}")
+        print(f"Max Stripes:     {int(conf.max_nr_stripes)}")
+        print(f"Reshape Stripes: {int(conf.reshape_stripes.counter)}")
+        print(f"Recovery Active: {int(mddev.recovery_active.counter)}")
+        print(f"Quiesce:         {int(conf.quiesce)}")
+        print()
+
+        stripes = md.find_hashed_stripes(conf)
+        print(f"Hashed Stripes: {len(stripes)}")
+
+        state_map = {}
+        for s in stripes:
+            state_map.setdefault(hex(s.state), []).append(s)
+
+        for state, lst in state_map.items():
+            print(f"  -- State: {state} Count: {len(lst)}")
+
+    except md.MDException as e:
+        print(e)


### PR DESCRIPTION
drgn can be a useful tool to dump some information in case of a hang in
md. Add as script which dumps some stats on active stripes and the
number of stripes in each state.

This requires a relatively recent version of drgn to be installed
(let's say 0.0.20 which isn't released yet).

There are instructions to install from source here:

  https://github.com/osandov/drgn

In the future, it may be installed with pip.

You can try running this on the next hang you get. It's a useful tool but usually I write something for purpose based on the bug.