### PR TITLE
test_all: Add --verify to basic test3 run in test_all

### DIFF
--- a/test_all
+++ b/test_all
@@ -18,7 +18,7 @@ def run_test(test, env=None):
 def run_all_tests(env):
     run_test(["./test1"], env)
     run_test(["./test2"], env)
-    run_test(["./test3"], env)
+    run_test(["./test3", "--verify"], env)
     run_test(["./test3_all"], env)
     run_test(["./test3", "-d"], env)
     if not env or env.get("NO_RESHAPE") != "y":


### PR DESCRIPTION
A recent data integrity bug made it past test_all. Add --verify to the
first run of test3 in test_all (without degrade or grow testing) to
catch future non-catastrophic data integrity bugs.