### PR TITLE
test3: Add md.wait() and second run_random()

### DIFF
--- a/test3
+++ b/test3
@@ -125,6 +125,10 @@ class TestRunner:
             if quick:
                 return
 
+    def wait_for_clean(self):
+        self.log("Waiting for clean")
+        self._md.wait()
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     group = parser.add_mutually_exclusive_group()
@@ -145,6 +149,8 @@ if __name__ == "__main__":
         if args.quick:
             cnt = 6
 
+        runner.run_random(cnt)
+        runner.wait_for_clean()
         runner.run_random(cnt)
 
         if args.grow_test:


### PR DESCRIPTION
test3 runs on disks which are not mounted in md with --assume-clean so
are not guarenteed to have a clean array before testing is finished.
This means that fast-path io may not be tested. Fix this by adding a
wait and second run_random to tests.