### PR TITLE
debug: Add more information to raid5_active.py

### DIFF
--- a/debug/md.py
+++ b/debug/md.py
@@ -1,6 +1,9 @@
 from drgn.helpers.linux.block import for_each_disk
-from drgn.helpers.linux.list import hlist_for_each_entry
+from drgn.helpers.linux.list import (hlist_for_each_entry, list_for_each_entry,
+                                     list_empty, list_for_each)
 from drgn import Object, sizeof
+
+import enum
 
 MD_MAJOR = 9
 
@@ -44,3 +47,84 @@ def find_hashed_stripes(conf):
             stripes.append(s)
 
     return stripes
+
+def stripe_in_list(list_head, stripe):
+    for s in list_for_each_entry("struct stripe_head", list_head, "lru"):
+        if s == stripe:
+            return True
+
+    return False
+
+NR_STRIPE_HASH_LOCKS=8
+def stripe_in_inactive_list(conf, stripe):
+    for i in range(NR_STRIPE_HASH_LOCKS):
+        if stripe_in_list(conf.inactive_list[i].address_of_(), stripe):
+            return True
+
+    return False
+
+def find_stripe_lru_list(conf, stripe):
+    if list_empty(stripe.lru.address_of_()):
+        return "none"
+    if stripe_in_inactive_list(conf, stripe):
+        return "inactive"
+
+    lists = {"handle_list": conf.handle_list,
+             "loprio_list": conf.loprio_list,
+             "hold_list": conf.hold_list,
+             "delayed_list": conf.delayed_list,
+             "bitmap_list": conf.bitmap_list}
+
+    for name, list_head in lists.items():
+        if stripe_in_list(list_head.address_of_(), stripe):
+            return name
+
+    return "unknown"
+
+class Raid5StripeState(enum.IntEnum):
+    STRIPE_ACTIVE = 0
+    STRIPE_HANDLE = enum.auto()
+    STRIPE_SYNC_REQUESTED = enum.auto()
+    STRIPE_SYNCING = enum.auto()
+    STRIPE_INSYNC = enum.auto()
+    STRIPE_REPLACED = enum.auto()
+    STRIPE_PREREAD_ACTIVE = enum.auto()
+    STRIPE_DELAYED = enum.auto()
+    STRIPE_DEGRADED = enum.auto()
+    STRIPE_BIT_DELAY = enum.auto()
+    STRIPE_EXPANDING = enum.auto()
+    STRIPE_EXPAND_SOURCE = enum.auto()
+    STRIPE_EXPAND_READY = enum.auto()
+    STRIPE_IO_STARTED = enum.auto()
+    STRIPE_FULL_WRITE = enum.auto()
+    STRIPE_BIOFILL_RUN = enum.auto()
+    STRIPE_COMPUTE_RUN = enum.auto()
+    STRIPE_ON_UNPLUG_LIST = enum.auto()
+    STRIPE_DISCARD = enum.auto()
+    STRIPE_ON_RELEASE_LIST = enum.auto()
+    STRIPE_BATCH_READY = enum.auto()
+    STRIPE_BATCH_ERR = enum.auto()
+    STRIPE_BITMAP_PENDING = enum.auto()
+    STRIPE_LOG_TRAPPED = enum.auto()
+    STRIPE_R5C_CACHING = enum.auto()
+    STRIPE_R5C_PARTIAL_STRIPE = enum.auto()
+    STRIPE_R5C_FULL_STRIPE = enum.auto()
+    STRIPE_R5C_PREFLUSH = enum.auto()
+
+def stripe_states(state):
+    states = []
+    for s in Raid5StripeState:
+        if (1 << s.value) & state:
+            states.append(s)
+    return states
+
+def print_stripe_info(conf, stripe):
+    print("Stripe Info:")
+    print(f"  Address:      {stripe.value_():x}")
+    print(f"  Sector:       {int(stripe.sector)}")
+    print(f"  State:        {hex(stripe.state)}")
+    for s in stripe_states(stripe.state):
+        print(f"                {s.name}")
+
+    lru_list = find_stripe_lru_list(conf, stripe)
+    print(f"  LRU List:     {lru_list}")

--- a/debug/raid5_active.py
+++ b/debug/raid5_active.py
@@ -31,5 +31,14 @@ if __name__ == "__main__":
         for state, lst in state_map.items():
             print(f"  -- State: {state} Count: {len(lst)}")
 
+        non_lru_stripes = []
+        for s in stripes:
+            if md.list_empty(s.lru.address_of_()):
+                non_lru_stripse.append(s)
+        print(f"Hashed Stripes not in LRU: {len(non_lru_stripes)}")
+
+        if non_lru_stripes:
+            md.print_stripe_info(conf, non_lru_stripes[0])
+
     except md.MDException as e:
         print(e)


### PR DESCRIPTION
Find any stripes not in the LRU and print information for the first
of those. This can be helpful in tracking down stripes that are
causing deadlocks.