### PR TITLE
Reduce --assume-clean confusion

### DIFF
--- a/md.py
+++ b/md.py
@@ -113,8 +113,10 @@ class MDArgumentParser(_EnvironmentArgumentParser):
         grp.add_argument("--devs", nargs="+",
                          help="specific disks to use")
 
-        grp.add_argument("--assume-clean", action="store_false",
+        grp.add_argument("--no-assume-clean", dest="assume-clean",
+                         action="store_false",
                          help="don't sync after creating the array")
+        grp.add_argument("--assume-clean", action="store_true", default=True)
         grp.add_argument("--force", action="store_true",
                          help="force mdadm creation")
         grp.add_argument("--zero-first", action="store_true",

--- a/md.py
+++ b/md.py
@@ -39,7 +39,7 @@ class _EnvironmentArgMixin:
             self._env_found = env
 
         envval = os.environ.get(env, action.default)
-        if action_type == "store_true":
+        if action_type in ("store_true", "store_false"):
             envval = self.to_bool(envval)
         nargs = kwargs.get("nargs", None)
         if ((nargs in ("+", "*") or isinstance(nargs, int)) and

--- a/test3
+++ b/test3
@@ -16,7 +16,7 @@ class TestRunner:
     VERIFICATION_SZ = 10 << 20
 
     def __init__(self, verify=False):
-        self._md = md.MDInstance.create_from_args(["--assume-clean"])
+        self._md = md.MDInstance.create_from_args(["--no-assume-clean"])
 
         self.verify_fd = None
         if verify:


### PR DESCRIPTION
using --assume-clean to disable --assume-clean in mdadm is confusing, add a --no-assume-clean option and use that to disable ---assume-clean instead. While we're at it fix a small bug in the envvarargs mixin when handling store_false arguments.

(Patches are based on @lsgunth's suggestrions in pr #13)