### PR TITLE
test2: Add retry attempts to umounts

### DIFF
--- a/test2
+++ b/test2
@@ -54,10 +54,17 @@ function drop_cache() {
 	echo 3 > /proc/sys/vm/drop_caches
 }
 
+function wait_umount() {
+	while ! umount /dev/md0 ; do
+		echo "/dev/md0 busy, waiting..."
+		sleep 1
+	done
+}
+
 function remount() {
 	echo REMOUNT
 	popd > /dev/null
-	umount /dev/md0
+	wait_umount
 	xfs_repair -e /dev/md0 2> /dev/null
 	mount /dev/md0 mnt
 	pushd mnt > /dev/null
@@ -66,7 +73,7 @@ function remount() {
 function atexit() {
 	dyndbg file raid5.c -p
 	popd > /dev/null
-	umount /dev/md0
+	wait_umount
 }
 
 mount /dev/md0 mnt


### PR DESCRIPTION
test2 occationally fails to umount an xfs mount leading to a hang on the
next test waiting for md0 to stop (which will never stop before the xfs
mount is unmounted). This failure is caused by a busy state in xfs.
correct this by retrying untill umount succeeds.