### PR TITLE
increase verification size on test3

### DIFF
--- a/test3
+++ b/test3
@@ -21,7 +21,13 @@ class TestRunner:
         self.verify_fd = None
         if verify:
             self.verify_disk = self._md.get_special_disk()
-            self._md.zero_all_disks(self.VERIFICATION_SZ)
+            min_disk_size = float('inf')
+            for dev in self._md.devs + [self.verify_disk]:
+                with open(dev) as f:
+                    disk_size = f.seek(0, os.SEEK_END)
+                    min_disk_size = min(min_disk_size, disk_size)
+            verify_size = self.VERIFICATION_SZ + min_disk_size // (8 * 1024)
+            self._md.zero_all_disks(verify_size)
             self.verify_fd = os.open(self.verify_disk, os.O_RDWR|os.O_DIRECT)
 
         self._md.setup()


### PR DESCRIPTION
When using large disks (in the TB range), the data section would start
considerably after what we were checking. This would cause errors such
as:

	Verifying
	/dev/md0 /dev/nvme4n1 differ: byte 6067713, line 1 is 325 M-U   0 ^@

Increase verify size to be proportional the size of the smallest disk in
the array.