### PR TITLE
Fix perf_test peak detection

### DIFF
--- a/perf_test
+++ b/perf_test
@@ -11,16 +11,23 @@ import subprocess as sp
 import tabulate
 import sys
 
-def bw_suffix(val):
-    suffixes = ["KiB/s", "MiB/s", "GiB/s"]
+def suffix(val, suffixes, base=1024):
     idx = 0
-    while val > 1024:
+    while val > base:
         idx += 1
-        val /= 1024
+        val /= base
     if val > 10:
         return f"{val:.1f} {suffixes[idx]}"
     else:
         return f"{val:.2f} {suffixes[idx]}"
+
+def bw_suffix(val):
+    suffixes = ["KiB/s", "MiB/s", "GiB/s"]
+    return suffix(val, suffixes)
+
+def iops_suffix(val):
+    suffixes = ["", "K", "M", "G"]
+    return suffix(val, suffixes, base=1000)
 
 def run_fio(fio, bs, chunk_size, thread_cnt, cache_size, bw, write):
     res = {"blocksize"   : bs,
@@ -47,8 +54,8 @@ def run_fio(fio, bs, chunk_size, thread_cnt, cache_size, bw, write):
         job_res = fio_res["result"]["jobs"][0][rw]
 
         name = f"Rnd {rw.capitalize()}"
-        res[f"{name} IOPS"] = {"suffix" : int(job_res["iops"]),
-                               "raw"    : int(job_res["iops"]),
+        res[f"{name} IOPS"] = {"suffix" : iops_suffix(job_res["iops"]),
+                               "raw"    : job_res["iops"],
         }
         if 'cpu' in fio_res:
             res[f"CPU User"] = f"{fio_res['cpu'].user}%"

--- a/perf_test
+++ b/perf_test
@@ -36,7 +36,9 @@ def run_fio(fio, bs, chunk_size, thread_cnt, cache_size, bw, write):
         job_res = fio_res["result"]["jobs"][0][rw]
 
         name = f"Seq {rw.capitalize()}"
-        res[f"{name} BW"] = bw_suffix(job_res["bw"])
+        res[f"{name} BW"] = {"suffix" : bw_suffix(job_res["bw"]),
+                             "raw"    : job_res["bw"]
+        }
         if 'cpu' in fio_res:
             res[f"CPU User"] = f"{fio_res['cpu'].user}%"
             res[f"CPU System"] = f"{fio_res['cpu'].system}%"
@@ -45,7 +47,9 @@ def run_fio(fio, bs, chunk_size, thread_cnt, cache_size, bw, write):
         job_res = fio_res["result"]["jobs"][0][rw]
 
         name = f"Rnd {rw.capitalize()}"
-        res[f"{name} IOPS"] = int(job_res["iops"])
+        res[f"{name} IOPS"] = {"suffix" : int(job_res["iops"]),
+                               "raw"    : int(job_res["iops"]),
+        }
         if 'cpu' in fio_res:
             res[f"CPU User"] = f"{fio_res['cpu'].user}%"
             res[f"CPU System"] = f"{fio_res['cpu'].system}%"
@@ -54,12 +58,12 @@ def run_fio(fio, bs, chunk_size, thread_cnt, cache_size, bw, write):
 
 def add_peak(results, peaks, bs, key):
     results_bs = filter(lambda x: x['blocksize'] == bs, results)
-    peak = max(results_bs, key=lambda x: x[key])
+    peak = max(results_bs, key=lambda x: x[key]["raw"])
 
     io_type = key.replace('BW', '').replace('IOPS', '').strip()
 
     peaks.setdefault(key, {})
-    peaks[key][bs] = {'Value'      : peak[key],
+    peaks[key][bs] = {'Value'      : peak[key]['suffix'],
                       'chunk_size' : peak['chunk_size'],
                       'thread_cnt' : peak['thread_cnt'],
                       'cache_size' : peak['cache_size'],
@@ -73,6 +77,7 @@ def pretty_print(results, title):
     headers = list(list(results.values())[0][0].keys())
     columns = [[list(v2.values()) for v2 in v1] for k1,v1 in results.items()]
     columns = list(itertools.chain(*columns))
+    columns = [[x if type(x) is not dict else x['suffix'] for x in c] for c in columns]
     print(title)
     print(tabulate.tabulate(columns, headers=headers))
     print()


### PR DESCRIPTION
When searching for the best performance across all results, we sort the
results list by different metrics (for example 'Seq Write BW').

However, these are stored as strings with suffixes (such as 9.3 GiB/s).

This "works" as long as all metrics have the same suffix (such as GiB/s)
and that all have the same number of whole digits (for example, this
breaks when comparing 9.3 and 10.0, since '9.3' > '10.0').

To fix this, store the metric with and without the suffix, so that we
can sort by latter and print the former.