### PR TITLE
md.py: Add small delay after md.recover

### DIFF
--- a/md.py
+++ b/md.py
@@ -366,3 +366,4 @@ class MDInstance:
     def recover(self, dev):
         subprocess.check_call([self.mdadm, "--manage", self.md_dev, "--quiet",
                                "--add-spare", dev])
+        time.sleep(0.1)


### PR DESCRIPTION
There appears to be a bug in base md when issuing io immediately after
recovery. Add a small delay to the md.recover call to work around
linux-eid-private issue #17 which exists in both raid5_fast code and
upstream. This workaround allows us to focus on issues in our own
changes rather than up-stream bugs.