### PR TITLE
perf_test: fix fio offset_increment

### DIFF
--- a/fio.py
+++ b/fio.py
@@ -6,13 +6,15 @@ import psutil
 import subprocess as sp
 
 class FIO:
+    _SIZE = 4<<30
+
     def __init__(self, path, cpu=False, executable="fio", **kargs):
         self.args = {
             "filename": path,
             "name": "md_test",
             "blocksize": 1 << 20,
             "runtime": 15,
-            "size": 4 << 30,
+            "size": self._SIZE,
             "numjobs": 16,
             "fallocate": "none",
             "time_based": 1,
@@ -21,7 +23,7 @@ class FIO:
             "direct": 1,
             "ioengine": "libaio",
             "iodepth": 2,
-            "offset_increment": "100M",
+            "offset_increment": self._SIZE,
             "output-format": "json",
         }
         self.cpu = cpu

--- a/perf_test
+++ b/perf_test
@@ -114,6 +114,8 @@ if __name__ == "__main__":
                      help="Measure CPU utilization.")
     grp.add_argument("--runtime", "-t", default="15s", help="fio runtime.")
     grp.add_argument("--ramptime", default=0, help="fio ramptime.")
+    grp.add_argument("--fio-size", default=4<<30, type=md_parser._suffix_parse,
+                     help="fio size")
 
     args = md_parser.parse_args()
 
@@ -141,7 +143,7 @@ if __name__ == "__main__":
               }
     inst = md.MDInstance.create_from_parsed_args(args)
     fio = FIO(inst.md_dev, cpu=args.cpu, runtime=args.runtime,
-              ramp_time=args.ramptime)
+              ramp_time=args.ramptime, size=args.fio_size)
 
     for chunk_size, thread_cnt, cache_size in md_options:
             inst.chunk_size = chunk_size

--- a/perf_test
+++ b/perf_test
@@ -29,7 +29,8 @@ def iops_suffix(val):
     suffixes = ["", "K", "M", "G"]
     return suffix(val, suffixes, base=1000)
 
-def run_fio(fio, bs, chunk_size, thread_cnt, cache_size, bw, write):
+def run_fio(fio, bs, chunk_size, thread_cnt, cache_size, bw, write,
+            offset_increment=0):
     res = {"blocksize"   : bs,
            "chunk_size"  : chunk_size,
            "thread_cnt"  : thread_cnt,
@@ -39,7 +40,8 @@ def run_fio(fio, bs, chunk_size, thread_cnt, cache_size, bw, write):
     rw = "write" if write else "read"
 
     if bw:
-        fio_res = fio.run(blocksize=bs, readwrite=rw)
+        fio_res = fio.run(blocksize=bs, readwrite=rw,
+                          offset_increment=offset_increment)
         job_res = fio_res["result"]["jobs"][0][rw]
 
         name = f"Seq {rw.capitalize()}"
@@ -50,7 +52,8 @@ def run_fio(fio, bs, chunk_size, thread_cnt, cache_size, bw, write):
             res[f"CPU User"] = f"{fio_res['cpu'].user}%"
             res[f"CPU System"] = f"{fio_res['cpu'].system}%"
     else:
-        fio_res = fio.run(blocksize=bs, readwrite=f"rand{rw}")
+        fio_res = fio.run(blocksize=bs, readwrite=f"rand{rw}",
+                          offset_increment=offset_increment)
         job_res = fio_res["result"]["jobs"][0][rw]
 
         name = f"Rnd {rw.capitalize()}"
@@ -151,13 +154,28 @@ if __name__ == "__main__":
             inst.cache_size = cache_size
             inst.setup()
 
+            if args.level == 5:
+                stripe_size = chunk_size * (args.disks - 1)
+            elif args.level == 6:
+                stripe_size = chunk_size * (args.disks - 2)
+            else:
+                stripe_size = 0
+
+            if stripe_size:
+                offset_increment = ((args.fio_size + stripe_size - 1)
+                                    // stripe_size
+                                    * stripe_size)
+            else:
+                offset_increment = args.fio_size
+
             for bs in args.bandwidth:
                 if args.write:
                     print(f"{done:.1f}%", end="\r")
                     res = run_fio(fio, bs=bs, chunk_size=chunk_size,
                                   thread_cnt=thread_cnt,
                                   cache_size=cache_size, bw=True,
-                                  write=True)
+                                  write=True,
+                                  offset_increment=offset_increment)
                     results['BW']['write'].setdefault(bs, [])
                     results['BW']['write'][bs].append(res)
                     done += step
@@ -167,7 +185,8 @@ if __name__ == "__main__":
                     res = run_fio(fio, bs=bs, chunk_size=chunk_size,
                                   thread_cnt=thread_cnt,
                                   cache_size=cache_size, bw=True,
-                                  write=False)
+                                  write=False,
+                                  offset_increment=offset_increment)
                     results['BW']['read'].setdefault(bs, [])
                     results['BW']['read'][bs].append(res)
                     done += step
@@ -178,7 +197,8 @@ if __name__ == "__main__":
                     res = run_fio(fio, bs=bs, chunk_size=chunk_size,
                                   thread_cnt=thread_cnt,
                                   cache_size=cache_size, bw=False,
-                                  write=True)
+                                  write=True,
+                                  offset_increment=offset_increment)
                     results['IOPS']['write'].setdefault(bs, [])
                     results['IOPS']['write'][bs].append(res)
                     done += step
@@ -188,7 +208,8 @@ if __name__ == "__main__":
                     res = run_fio(fio, bs=bs, chunk_size=chunk_size,
                                   thread_cnt=thread_cnt,
                                   cache_size=cache_size, bw=False,
-                                  write=False)
+                                  write=False,
+                                  offset_increment=offset_increment)
                     results['IOPS']['read'].setdefault(bs, [])
                     results['IOPS']['read'][bs].append(res)
                     done += step


### PR DESCRIPTION
The 100M offset_increment was not enough to prevent overlap, set it to
the same value as "size" to prevent threads from overlapping.

While we're at it, also make it aligned to stripe size.